### PR TITLE
Change `jsx` resolution to not depend on `react/jsx-runtime`

### DIFF
--- a/packages/web/src/react.tsx
+++ b/packages/web/src/react.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { inject } from './generic';
 import type { BeforeSend } from './types';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "noUnusedLocals": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
This will transpile to `React.createElement` instead. Fixes #2.