### PR TITLE
Remove named tuples to support older TS versions

### DIFF
--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -11,7 +11,7 @@ declare global {
     // Base interface
     va?: (event: string, properties?: unknown) => void;
     // Queue for actions, before the library is loaded
-    vaq?: [string, unknown][];
+    vaq?: [string, unknown?][];
     vai?: boolean;
   }
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -11,7 +11,7 @@ declare global {
     // Base interface
     va?: (event: string, properties?: unknown) => void;
     // Queue for actions, before the library is loaded
-    vaq?: [event: string, properties?: unknown][];
+    vaq?: [string, unknown][];
     vai?: boolean;
   }
 }


### PR DESCRIPTION
This feature wasn't supported in older Typescript versions (<3), I think it's worth giving up for better support.