### PR TITLE
Use defer instead of async

### DIFF
--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -17,7 +17,7 @@ export const inject = ({
 
   const script = document.createElement('script');
   script.src = '/va/script.js';
-  script.async = true;
+  script.defer = true;
 
   document.head.appendChild(script);
 };


### PR DESCRIPTION
In order to improve script loading, use `defer` instead of `async`.