### PR TITLE
Just use development mode when NODE_ENV is development or test

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "0.1.5",
+  "version": "0.1.5-beta.0",
   "keywords": [
     "analytics",
     "vercel"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "0.1.5-beta.0",
+  "version": "0.1.5",
   "keywords": [
     "analytics",
     "vercel"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "keywords": [
     "analytics",
     "vercel"

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -3,7 +3,8 @@ export function isBrowser(): boolean {
 }
 
 export function isDevelopment(): boolean {
+  if (typeof process === 'undefined') return false;
   return (
-    typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'
+    process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
   );
 }


### PR DESCRIPTION
The package sometimes uses the debug script for some special setups. Fix this by only using the `development` script when `NODE_ENV` is set to `development` or `test`