### PR TITLE
Fix mismatch of queued events

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "0.1.9-beta.2",
+  "version": "0.1.9-beta.3",
   "keywords": [
     "analytics",
     "vercel"

--- a/packages/web/src/generic.test.ts
+++ b/packages/web/src/generic.test.ts
@@ -62,7 +62,7 @@ describe('track custom events', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'my event',
           },
@@ -80,7 +80,7 @@ describe('track custom events', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'custom event',
             data: {
@@ -106,7 +106,7 @@ describe('track custom events', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'custom event',
             data: {
@@ -137,7 +137,7 @@ describe('track custom events', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'my event',
           },
@@ -155,7 +155,7 @@ describe('track custom events', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'custom event',
             data: {

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -45,7 +45,7 @@ export const track = (
   properties?: Record<string, AllowedPropertyValues>,
 ): void => {
   if (!properties) {
-    window.va?.('track', { name });
+    window.va?.('event', { name });
     return;
   }
 
@@ -54,7 +54,7 @@ export const track = (
       strip: isProduction(),
     });
 
-    window.va?.('track', {
+    window.va?.('event', {
       name,
       data: props,
     });

--- a/packages/web/src/react.test.tsx
+++ b/packages/web/src/react.test.tsx
@@ -64,7 +64,7 @@ describe('<Analytics />', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'my event',
           },
@@ -84,7 +84,7 @@ describe('<Analytics />', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'custom event',
             data: {
@@ -112,7 +112,7 @@ describe('<Analytics />', () => {
         if (!window.vaq) throw new Error('window.vaq is not defined');
 
         expect(window.vaq[0]).toEqual([
-          'track',
+          'event',
           {
             name: 'custom event',
             data: {

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -17,7 +17,7 @@ export interface AnalyticsProps {
 declare global {
   interface Window {
     // Base interface
-    va?: (event: string, properties?: unknown) => void;
+    va?: (event: 'beforeSend' | 'event', properties?: unknown) => void;
     // Queue for actions, before the library is loaded
     vaq?: [string, unknown?][];
     vai?: boolean;


### PR DESCRIPTION
The analytics-script listens for `event` and not `track`