### PR TITLE
web/react: add use client directive to react component

### DIFF
--- a/packages/web/src/react.tsx
+++ b/packages/web/src/react.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from 'react';
 import { inject } from './generic';
 import type { AnalyticsProps } from './types';


### PR DESCRIPTION
This should remove the need for consumers to wrap vercel/analytics in its own client component