### PR TITLE
Prepend "use client" to react component after build

### DIFF
--- a/packages/web/tsup.config.js
+++ b/packages/web/tsup.config.js
@@ -23,5 +23,11 @@ export default defineConfig([
       index: 'src/react.tsx',
     },
     outDir: 'dist/react',
+    esbuildOptions: (options) => {
+      // Append "use client" to the top of the react entry point
+      options.banner = {
+        js: '"use client";',
+      };
+    },
   },
 ]);


### PR DESCRIPTION
Add `"use client"` to the react component to simplify implementation with Next.js `/app` directory.

This closes #36 