### PR TITLE
`track` should only run in browser environments

### DIFF
--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -44,6 +44,8 @@ export const track = (
   name: string,
   properties?: Record<string, AllowedPropertyValues>,
 ): void => {
+  if (!isBrowser()) return;
+
   if (!properties) {
     window.va?.('event', { name });
     return;


### PR DESCRIPTION
If `window` is not defined, just return