### PR TITLE
Fix `mode` detection for Remix

### DIFF
--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -5,10 +5,13 @@ export function isBrowser(): boolean {
 }
 
 export function isDevelopment(): boolean {
-  if (typeof process === 'undefined') return false;
-  return (
-    process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
-  );
+  try {
+    return (
+      process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
+    );
+  } catch (e) {
+    return false;
+  }
 }
 
 export function getMode(mode: Mode = 'auto'): Mode {

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -6,9 +6,8 @@ export function isBrowser(): boolean {
 
 export function isDevelopment(): boolean {
   try {
-    return (
-      process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
-    );
+    const env = process.env.NODE_ENV;
+    return env === 'development' || env === 'test';
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
In Remix, `process` is not defined which makes our `isDevelopment()` fail. However, `process.env.NODE_ENV` gets replaced during the build time. By accessing it directly we can get access to the value.