### PR TITLE
Use new domain for dev script

### DIFF
--- a/packages/web/src/generic.test.ts
+++ b/packages/web/src/generic.test.ts
@@ -15,7 +15,7 @@ describe('inject', () => {
       }
 
       expect(script.src).toEqual(
-        'https://cdn.vercel-insights.com/v1/script.debug.js',
+        'https://va.vercel-scripts.com/v1/script.debug.js',
       );
       expect(script).toHaveAttribute('defer');
     });

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -20,7 +20,7 @@ export const inject = (
 
   const src =
     mode === 'development'
-      ? 'https://cdn.vercel-insights.com/v1/script.debug.js'
+      ? 'https://va.vercel-scrips.com/v1/script.debug.js'
       : '/_vercel/insights/script.js';
 
   if (document.head.querySelector(`script[src*="${src}"]`)) return;

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -20,7 +20,7 @@ export const inject = (
 
   const src =
     mode === 'development'
-      ? 'https://va.vercel-scrips.com/v1/script.debug.js'
+      ? 'https://va.vercel-scripts.com/v1/script.debug.js'
       : '/_vercel/insights/script.js';
 
   if (document.head.querySelector(`script[src*="${src}"]`)) return;

--- a/packages/web/src/react.test.tsx
+++ b/packages/web/src/react.test.tsx
@@ -21,7 +21,7 @@ describe('<Analytics />', () => {
       }
 
       expect(script.src).toEqual(
-        'https://cdn.vercel-insights.com/v1/script.debug.js',
+        'https://va.vercel-scripts.com/v1/script.debug.js',
       );
       expect(script).toHaveAttribute('defer');
     });


### PR DESCRIPTION
⚠️ Before merging, **make sure the new domain has been assigned**: https://va.vercel-scripts.com/v1/script.debug.js

Replace our `vercel-insights.com` domain, with our new `vercel-scripts.com` domain.

The domain has been ad-blocked, as it is to ingest data for Speed Insights. The new domain is for dev usage only, so it should not be blocked.
