### PR TITLE
Add JSDoc comments for easier usage

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,6 +48,9 @@
     "extends": [
       "@vercel/eslint-config"
     ],
+    "rules": {
+      "tsdoc/syntax": "off"
+    },
     "ignorePatterns": [
       "jest.setup.ts"
     ]

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -9,6 +9,16 @@ import {
   isProduction,
 } from './utils';
 
+/**
+ * Injects the Vercel Web Analytics script into the page head and starts tracking page views. Read more in our [documentation](https://vercel.com/docs/concepts/analytics/package).
+ * @param [props] - Analytics options.
+ * @param [props.mode] - The mode to use for the analytics script. Defaults to `auto`.
+ *  - `auto` - Automatically detect the environment.  Uses `production` if the environment cannot be determined.
+ *  - `production` - Always use the production script. (Sends events to the server)
+ *  - `development` - Always use the development script. (Logs events to the console)
+ * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
+ * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
+ */
 export function inject(
   props: AnalyticsProps = {
     debug: true,
@@ -43,6 +53,12 @@ export function inject(
   document.head.appendChild(script);
 }
 
+/**
+ * Tracks a custom event. Please refer to the [documentation](https://vercel.com/docs/concepts/analytics/custom-events) for more information on custom events.
+ * @param name - The name of the event.
+ * * Examples: `Purchase`, `Click Button`, or `Play Video`.
+ * @param [properties] - Additional properties of the event. Nested objects are not supported. Allowed values are `string`, `number`, `boolean`, and `null`.
+ */
 export function track(
   name: string,
   properties?: Record<string, AllowedPropertyValues>,
@@ -82,5 +98,3 @@ export default {
   inject,
   track,
 };
-
-export type { BeforeSendEvent } from './types';

--- a/packages/web/src/react.tsx
+++ b/packages/web/src/react.tsx
@@ -2,6 +2,29 @@ import { useEffect } from 'react';
 import { inject, track } from './generic';
 import type { AnalyticsProps } from './types';
 
+/**
+ * Injects the Vercel Web Analytics script into the page head and starts tracking page views. Read more in our [documentation](https://vercel.com/docs/concepts/analytics/package).
+ * @param [props] - Analytics options.
+ * @param [props.mode] - The mode to use for the analytics script. Defaults to `auto`.
+ *  - `auto` - Automatically detect the environment.  Uses `production` if the environment cannot be determined.
+ *  - `production` - Always use the production script. (Sends events to the server)
+ *  - `development` - Always use the development script. (Logs events to the console)
+ * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
+ * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
+ * @example
+ * ```js
+ * import { Analytics } from '@vercel/analytics';
+ *
+ * export default function App() {
+ *  return (
+ *   <div>
+ *    <Analytics />
+ *    <h1>My App</h1>
+ *  </div>
+ * );
+ * }
+ * ```
+ */
 function Analytics({
   beforeSend,
   debug = true,

--- a/packages/web/src/react.tsx
+++ b/packages/web/src/react.tsx
@@ -13,7 +13,7 @@ import type { AnalyticsProps } from './types';
  * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
  * @example
  * ```js
- * import { Analytics } from '@vercel/analytics';
+ * import { Analytics } from '@vercel/analytics/react';
  *
  * export default function App() {
  *  return (

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -13,7 +13,6 @@ export type Mode = 'auto' | 'development' | 'production';
 export type AllowedPropertyValues = string | number | boolean | null;
 
 export type BeforeSend = (event: BeforeSendEvent) => BeforeSendEvent | null;
-
 export interface AnalyticsProps {
   beforeSend?: BeforeSend;
   debug?: boolean;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -14,15 +14,6 @@ export type AllowedPropertyValues = string | number | boolean | null;
 
 export type BeforeSend = (event: BeforeSendEvent) => BeforeSendEvent | null;
 
-/**
- * Analytics properties.
- * @param [props.mode] - The mode to use for the analytics script. Defaults to `auto`.
- * - `auto` - Automatically detect the environment.  Uses `production` if the environment cannot be detected.
- * - `production` - Always use the production script. (Sends events to the server)
- * - `development` - Always use the development script. (Logs events to the console)
- * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
- * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
- */
 export interface AnalyticsProps {
   beforeSend?: BeforeSend;
   debug?: boolean;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -13,6 +13,16 @@ export type Mode = 'auto' | 'development' | 'production';
 export type AllowedPropertyValues = string | number | boolean | null;
 
 export type BeforeSend = (event: BeforeSendEvent) => BeforeSendEvent | null;
+
+/**
+ * Analytics properties.
+ * @param [props.mode] - The mode to use for the analytics script. Defaults to `auto`.
+ * - `auto` - Automatically detect the environment.  Uses `production` if the environment cannot be detected.
+ * - `production` - Always use the production script. (Sends events to the server)
+ * - `development` - Always use the development script. (Logs events to the console)
+ * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
+ * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
+ */
 export interface AnalyticsProps {
   beforeSend?: BeforeSend;
   debug?: boolean;


### PR DESCRIPTION
Make the library even easier to use, by inlining our library docs.

* Disable default linting rules to be able to document an object
* Unfortunately we have some duplication, which we can't avoid if don't go all in on JSDoc types

## Sample Screenshots
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/1440854/234878344-5f034b44-eb48-44f0-8b16-c534743cf158.png">
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/1440854/234878713-21f06e47-5a70-4a55-bcef-c2b39504b6ee.png">

