### PR TITLE
Improved server side events

### DIFF
--- a/apps/nextjs/app/api/edge/route.ts
+++ b/apps/nextjs/app/api/edge/route.ts
@@ -1,5 +1,4 @@
-import { track } from '@vercel/analytics/server';
-import { withRequestContext } from '@vercel/analytics/server';
+import { withSessionContext, track } from '@vercel/analytics/server';
 
 export const runtime = 'edge';
 
@@ -12,4 +11,4 @@ async function handler() {
   return new Response('OK');
 }
 
-export const GET = withRequestContext(handler);
+export const GET = withSessionContext(handler);

--- a/apps/nextjs/app/api/serverless/route.ts
+++ b/apps/nextjs/app/api/serverless/route.ts
@@ -1,5 +1,4 @@
-import { withRequestContext, track } from '@vercel/analytics/server';
-import { NextRequest } from 'next/server';
+import { withSessionContext, track } from '@vercel/analytics/server';
 
 async function handler() {
   await track('Serverless Event', {
@@ -9,4 +8,4 @@ async function handler() {
   return new Response('OK');
 }
 
-export const GET = withRequestContext(handler);
+export const GET = withSessionContext(handler);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -97,9 +97,10 @@ export async function track(
       body: JSON.stringify(body),
       method: 'POST',
     }).catch((err: unknown) => {
-      if (!(err instanceof Error)) return;
-      if ('response' in err) {
+      if (err instanceof Error && 'response' in err) {
         console.error(err.response);
+      } else {
+        console.error(err);
       }
     });
 

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -88,7 +88,7 @@ export async function track(
 
     if (!ENDPOINT) {
       throw new Error(
-        'VERCEL_URL is not defined in the environment variables.',
+        '`process.env.VERCEL_URL` is not defined in your environment variables.',
       );
     }
 

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -82,7 +82,7 @@ export async function track(
 
     if (!hasHeaders) {
       throw new Error(
-        'No headers or request found. Please use `withSessionContext` to wrap your request handler or pass in `request` order `headers` to `track`.',
+        'No session context found. Wrap your API route handler with `withSessionContext` or pass `request` or `headers` to the `track` function.',
       );
     }
 

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -80,10 +80,22 @@ export async function track(
 
     const hasHeaders = Boolean(headers);
 
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    if (!hasHeaders) {
+      throw new Error(
+        'No headers or request found. Please use `withSessionContext` to wrap your request handler or pass in `request` order `headers` to `track`.',
+      );
+    }
+
+    if (!ENDPOINT) {
+      throw new Error(
+        'VERCEL_URL is not defined in the environment variables.',
+      );
+    }
+
     const promise = fetch(`https://${ENDPOINT}/_vercel/insights/event`, {
       headers: {
         'content-type': 'application/json',
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- The throwing is temporary until we add support for non Vercel hosted environments
         ...(hasHeaders
           ? {
               'user-agent': tmp['user-agent'] as string,

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -3,7 +3,7 @@
 import type { AllowedPropertyValues } from '../types';
 import type { StorageData } from './request-context';
 
-export { withRequestContext } from './request-context';
+export { withSessionContext } from './request-context';
 
 const ENDPOINT = process.env.VERCEL_URL || process.env.VERCEL_ANALYTICS_URL;
 const ENV = process.env.NODE_ENV;

--- a/packages/web/src/server/request-context.ts
+++ b/packages/web/src/server/request-context.ts
@@ -4,7 +4,7 @@ export interface StorageData {
   request: Request;
 }
 
-export const withRequestContext =
+export const withSessionContext =
   <T extends Request>(next: (req: any, res: any) => Promise<Response | void>) =>
   async (request: T, secondParam: Response): Promise<Response | void> => {
     const asyncLocalStorage = new AsyncLocalStorage<StorageData>();


### PR DESCRIPTION
- Rename `withRequestContext` to `withSessionContext`
- Throw an error when no headers are found (either by context or manually passing)
- Print more errors when something is wrong