### PR TITLE
Add missing export for AnalyticsProps

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -19,7 +19,7 @@ import {
  * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
  * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
  */
-export function inject(
+function inject(
   props: AnalyticsProps = {
     debug: true,
   },
@@ -70,7 +70,7 @@ export function inject(
  * * Examples: `Purchase`, `Click Button`, or `Play Video`.
  * @param [properties] - Additional properties of the event. Nested objects are not supported. Allowed values are `string`, `number`, `boolean`, and `null`.
  */
-export function track(
+function track(
   name: string,
   properties?: Record<string, AllowedPropertyValues>,
 ): void {
@@ -103,6 +103,9 @@ export function track(
     }
   }
 }
+
+export { inject, track };
+export type { AnalyticsProps };
 
 // eslint-disable-next-line import/no-default-export
 export default {

--- a/packages/web/src/react.tsx
+++ b/packages/web/src/react.tsx
@@ -36,6 +36,7 @@ function Analytics({
 
   return null;
 }
+
 export { track, Analytics };
 export type { AnalyticsProps };
 


### PR DESCRIPTION
I noticed we're not exporting `AnalyticsProps` on the generic package.
I also reordered the exports to match our exports on the react side.