### PR TITLE
More server events improvments

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.1.0-beta.5",
+  "version": "1.1.0-beta.6",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -66,6 +66,9 @@
       "jest.setup.ts"
     ]
   },
+  "dependencies": {
+    "server-only": "^0.0.1"
+  },
   "devDependencies": {
     "@swc/core": "^1.3.66",
     "@swc/jest": "^0.2.26",

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -75,10 +75,16 @@ function track(
   properties?: Record<string, AllowedPropertyValues>,
 ): void {
   if (!isBrowser()) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      '[Vercel Web Analytics] Server-side execution of `track()` is currently not supported.',
-    );
+    const msg =
+      '[Vercel Web Analytics] Please import `track` from `@vercel/analytics/server` when using this function in a server environment';
+
+    if (isProduction()) {
+      // eslint-disable-next-line no-console
+      console.warn(msg);
+    } else {
+      throw new Error(msg);
+    }
+
     return;
   }
 

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -5,6 +5,7 @@ import type { AllowedPropertyValues } from '../types';
 const ENDPOINT = process.env.VERCEL_URL || process.env.VERCEL_ANALYTICS_URL;
 const ENV = process.env.NODE_ENV;
 const IS_DEV = ENV === 'development';
+const DISABLE_LOGS = Boolean(process.env.VERCEL_WEB_ANALYTICS_DISABLE_LOGS);
 
 type HeadersObject = Record<string, string | string[] | undefined>;
 type AllowedHeaders = Headers | HeadersObject;
@@ -60,6 +61,8 @@ export async function track(
     }
 
     if (!ENDPOINT && IS_DEV) {
+      if (!DISABLE_LOGS) return;
+
       console.log(
         `[Vercel Web Analytics] Track "${eventName}" ${
           properties ? `with data ${JSON.stringify(properties)}` : ''

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -39,10 +39,22 @@ export async function track(
   properties?: Record<string, AllowedPropertyValues>,
   context?: Context,
 ): Promise<void> {
-  if (!ENDPOINT && isProduction()) {
-    console.log(
-      `[Vercel Web Analytics] Can't find VERCEL_URL in environment variables.`,
-    );
+  const props = parseProperties(properties, {
+    strip: isProduction(),
+  });
+
+  if (!ENDPOINT) {
+    if (isProduction()) {
+      console.log(
+        `[Vercel Web Analytics] Can't find VERCEL_URL in environment variables.`,
+      );
+    } else if (!DISABLE_LOGS) {
+      console.log(
+        `[Vercel Web Analytics] Track "${eventName}" ${
+          props ? `with data ${JSON.stringify(props)}` : ''
+        }`,
+      );
+    }
     return;
   }
   try {
@@ -59,21 +71,6 @@ export async function track(
     } else if (requestContext?.headers) {
       // not explicitly passed in context, so take it from async storage
       headers = requestContext.headers;
-    }
-
-    const props = parseProperties(properties, {
-      strip: isProduction(),
-    });
-
-    if (!ENDPOINT && isDevelopment()) {
-      if (!DISABLE_LOGS) return;
-
-      console.log(
-        `[Vercel Web Analytics] Track "${eventName}" ${
-          props ? `with data ${JSON.stringify(props)}` : ''
-        }`,
-      );
-      return;
     }
 
     let tmp: HeadersObject = {};

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -26,7 +26,8 @@ export function setMode(mode: Mode = 'auto'): void {
 }
 
 export function getMode(): Mode {
-  return window.vam || 'production';
+  const mode = isBrowser() ? window.vam : detectEnvironment();
+  return mode || 'production';
 }
 
 export function isProduction(): boolean {
@@ -45,11 +46,12 @@ function removeKey(
 }
 
 export function parseProperties(
-  properties: Record<string, unknown>,
+  properties: Record<string, unknown> | undefined,
   options: {
     strip?: boolean;
   },
 ): Error | Record<string, AllowedPropertyValues> | undefined {
+  if (!properties) return undefined;
   let props = properties;
   const errorProperties: string[] = [];
   for (const [key, value] of Object.entries(properties)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,10 @@ importers:
         version: 5.1.3
 
   packages/web:
+    dependencies:
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
     devDependencies:
       '@swc/core':
         specifier: ^1.3.66
@@ -7042,6 +7046,13 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+
+  /server-only@0.0.1:
+    resolution:
+      {
+        integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==,
+      }
+    dev: false
 
   /shebang-command@2.0.0:
     resolution:


### PR DESCRIPTION
- Allow to disable logs using environment variable `VERCEL_WEB_ANALYTICS_DISABLE_LOGS`  Fixes #ALY-951
- Throw error when importing `track` from `@vercel/analytics` instead of `@vercel/analytics/server`. This only logs a warning when on **production**.
<img width="1007" alt="image" src="https://github.com/vercel/analytics/assets/2978876/0905cb01-41c9-492a-8e3e-4a31d17fec98">
- Throw an error when `/server` is imported on a client component (using `server-only` package)