### PR TITLE
Force HTTPS for server-side events

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -91,13 +91,19 @@ export async function track(
       tmp = headers;
     }
 
-    const origin =
-      requestContext?.url || (tmp.referer as string) || `https://${ENDPOINT}`;
+    const referer = tmp.referer as string | undefined;
+
+    const origin = requestContext?.url || referer || `https://${ENDPOINT}`;
 
     const url = new URL(origin);
 
+    // Ensure that the protocol is HTTPS
+    if (url.protocol !== 'https:') {
+      url.protocol = 'https:';
+    }
+
     const body = {
-      o: origin,
+      o: referer || url.toString(),
       ts: new Date().getTime(),
       r: '',
       en: eventName,


### PR DESCRIPTION
- Always set the protocol to https (our endpoint always come with https)
- Also prefer `referer` if its available for better data (non required)