### PR TITLE
Add scriptSrc & endpoint props

### DIFF
--- a/packages/web/src/generic.test.ts
+++ b/packages/web/src/generic.test.ts
@@ -38,6 +38,25 @@ describe('inject', () => {
       expect(script).toHaveAttribute('defer');
     });
   });
+
+  describe('with a scriptSrc', () => {
+    it('should add the script tag correctly', () => {
+      const customSrc = 'http://localhost/custom-path/_vercel/insights/script.js';
+      inject({ scriptSrc: customSrc });
+
+      const scripts = document.getElementsByTagName('script');
+      expect(scripts).toHaveLength(1);
+
+      const script = document.head.querySelector('script');
+
+      if (!script) {
+        throw new Error('Could not find script tag');
+      }
+
+      expect(script.src).toEqual(customSrc);
+      expect(script).toHaveAttribute('defer');
+    });
+  });
 });
 
 describe('track custom events', () => {

--- a/packages/web/src/generic.test.ts
+++ b/packages/web/src/generic.test.ts
@@ -41,7 +41,8 @@ describe('inject', () => {
 
   describe('with a scriptSrc', () => {
     it('should add the script tag correctly', () => {
-      const customSrc = 'http://localhost/custom-path/_vercel/insights/script.js';
+      const customSrc =
+        'http://localhost/custom-path/_vercel/insights/script.js';
       inject({ scriptSrc: customSrc });
 
       const scripts = document.getElementsByTagName('script');
@@ -54,6 +55,25 @@ describe('inject', () => {
       }
 
       expect(script.src).toEqual(customSrc);
+      expect(script).toHaveAttribute('defer');
+    });
+  });
+
+  describe('with a custom endpoint', () => {
+    it('should add the script tag correctly', () => {
+      const customEndpoint = 'http://localhost/custom-path/_vercel/insights';
+      inject({ scriptSrc: customEndpoint });
+
+      const scripts = document.getElementsByTagName('script');
+      expect(scripts).toHaveLength(1);
+
+      const script = document.head.querySelector('script');
+
+      if (!script) {
+        throw new Error('Could not find script tag');
+      }
+
+      expect(script.dataset.endpoint).toEqual(customEndpoint);
       expect(script).toHaveAttribute('defer');
     });
   });

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -18,6 +18,7 @@ import {
  *  - `development` - Always use the development script. (Logs events to the console)
  * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
  * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
+ * @param [props.scriptSrc] - Manually specify the script source URL.
  */
 function inject(
   props: AnalyticsProps = {
@@ -34,7 +35,7 @@ function inject(
     window.va?.('beforeSend', props.beforeSend);
   }
 
-  const src = isDevelopment()
+  const src = props.scriptSrc || isDevelopment()
     ? 'https://va.vercel-scripts.com/v1/script.debug.js'
     : '/_vercel/insights/script.js';
 

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -19,6 +19,7 @@ import {
  * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
  * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
  * @param [props.scriptSrc] - Manually specify the script source URL.
+ * @param [props.endpoint] - Manually specify the endpoint URL.
  */
 function inject(
   props: AnalyticsProps = {
@@ -35,9 +36,10 @@ function inject(
     window.va?.('beforeSend', props.beforeSend);
   }
 
-  const src = props.scriptSrc || isDevelopment()
-    ? 'https://va.vercel-scripts.com/v1/script.debug.js'
-    : '/_vercel/insights/script.js';
+  const src =
+    props.scriptSrc || isDevelopment()
+      ? 'https://va.vercel-scripts.com/v1/script.debug.js'
+      : '/_vercel/insights/script.js';
 
   if (document.head.querySelector(`script[src*="${src}"]`)) return;
 
@@ -46,6 +48,10 @@ function inject(
   script.defer = true;
   script.setAttribute('data-sdkn', packageName);
   script.setAttribute('data-sdkv', version);
+
+  if (props.endpoint) {
+    script.setAttribute('data-endpoint', props.endpoint);
+  }
 
   script.onerror = (): void => {
     const errorMessage = isDevelopment()

--- a/packages/web/src/react.tsx
+++ b/packages/web/src/react.tsx
@@ -12,6 +12,7 @@ import type { AnalyticsProps } from './types';
  * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
  * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
  * @param [props.scriptSrc] -  Manually specify the script source URL.
+ * @param [props.endpoint] -  Manually specify the endpoint URL.
  * @example
  * ```js
  * import { Analytics } from '@vercel/analytics/react';
@@ -31,10 +32,11 @@ function Analytics({
   debug = true,
   mode = 'auto',
   scriptSrc,
+  endpoint,
 }: AnalyticsProps): null {
   useEffect(() => {
-    inject({ beforeSend, debug, mode, scriptSrc });
-  }, [beforeSend, debug, mode, scriptSrc]);
+    inject({ beforeSend, debug, mode, scriptSrc, endpoint });
+  }, [beforeSend, debug, mode, scriptSrc, endpoint]);
 
   return null;
 }

--- a/packages/web/src/react.tsx
+++ b/packages/web/src/react.tsx
@@ -11,6 +11,7 @@ import type { AnalyticsProps } from './types';
  *  - `development` - Always use the development script. (Logs events to the console)
  * @param [props.debug] - Whether to enable debug logging in development. Defaults to `true`.
  * @param [props.beforeSend] - A middleware function to modify events before they are sent. Should return the event object or `null` to cancel the event.
+ * @param [props.scriptSrc] -  Manually specify the script source URL.
  * @example
  * ```js
  * import { Analytics } from '@vercel/analytics/react';
@@ -29,10 +30,11 @@ function Analytics({
   beforeSend,
   debug = true,
   mode = 'auto',
+  scriptSrc,
 }: AnalyticsProps): null {
   useEffect(() => {
-    inject({ beforeSend, debug, mode });
-  }, [beforeSend, debug, mode]);
+    inject({ beforeSend, debug, mode, scriptSrc });
+  }, [beforeSend, debug, mode, scriptSrc]);
 
   return null;
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -18,6 +18,7 @@ export interface AnalyticsProps {
   debug?: boolean;
   mode?: Mode;
   scriptSrc?: string;
+  endpoint?: string;
 }
 declare global {
   interface Window {

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -17,6 +17,7 @@ export interface AnalyticsProps {
   beforeSend?: BeforeSend;
   debug?: boolean;
   mode?: Mode;
+  scriptSrc?: string;
 }
 declare global {
   interface Window {


### PR DESCRIPTION
This adds `scriptSrc` and `endpoint` to match the [speed-insights props](https://github.com/vercel/speed-insights/blob/main/packages/web/src/types.ts#L8), and allows Next.js implementations that use a different basePath to directly leverage the react component version of @vercel/analytics.

