### PR TITLE
fix(build): add peer and optional deps

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -84,5 +84,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tsup": "7.1.0"
+  },
+  "peerDependencies": {
+    "react": "^18"
+  },
+  "optionalDependencies": {
+    "react": "^18"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -88,7 +88,9 @@
   "peerDependencies": {
     "react": "^18"
   },
-  "optionalDependencies": {
-    "react": "^18"
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,10 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+    optionalDependencies:
+      react:
+        specifier: ^18
+        version: 18.2.0
     devDependencies:
       '@swc/core':
         specifier: ^1.3.66
@@ -171,9 +175,6 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.5.0
         version: 29.5.0
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
@@ -3104,13 +3105,6 @@ packages:
       parse5: 7.1.2
     dev: true
 
-  /@types/json-schema@7.0.11:
-    resolution:
-      {
-        integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==,
-      }
-    dev: true
-
   /@types/json-schema@7.0.13:
     resolution:
       {
@@ -3207,13 +3201,6 @@ packages:
     resolution:
       {
         integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==,
-      }
-    dev: true
-
-  /@types/semver@7.3.12:
-    resolution:
-      {
-        integrity: sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==,
       }
     dev: true
 
@@ -3445,17 +3432,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@5.40.1:
-    resolution:
-      {
-        integrity: sha512-jkn4xsJiUQucI16OLCXrLRXDZ3afKhOIqXs4R3O+M00hdQLKR58WuyXPZZjhKLFCEP2g+TXdBRtLQ33UfAdRUg==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-    dependencies:
-      '@typescript-eslint/types': 5.40.1
-      '@typescript-eslint/visitor-keys': 5.40.1
-    dev: true
-
   /@typescript-eslint/scope-manager@5.62.0:
     resolution:
       {
@@ -3547,14 +3523,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@5.40.1:
-    resolution:
-      {
-        integrity: sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-    dev: true
-
   /@typescript-eslint/types@5.62.0:
     resolution:
       {
@@ -3569,30 +3537,6 @@ packages:
         integrity: sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==,
       }
     engines: { node: ^16.0.0 || >=18.0.0 }
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.40.1(typescript@5.1.3):
-    resolution:
-      {
-        integrity: sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.40.1
-      '@typescript-eslint/visitor-keys': 5.40.1
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.3):
@@ -3715,29 +3659,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.40.1(eslint@8.43.0)(typescript@5.1.3):
-    resolution:
-      {
-        integrity: sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.12
-      '@typescript-eslint/scope-manager': 5.40.1
-      '@typescript-eslint/types': 5.40.1
-      '@typescript-eslint/typescript-estree': 5.40.1(typescript@5.1.3)
-      eslint: 8.43.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.43.0)
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/utils@5.62.0(eslint@8.43.0)(typescript@5.1.3):
     resolution:
       {
@@ -3849,17 +3770,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@typescript-eslint/visitor-keys@5.40.1:
-    resolution:
-      {
-        integrity: sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-    dependencies:
-      '@typescript-eslint/types': 5.40.1
-      eslint-visitor-keys: 3.3.0
     dev: true
 
   /@typescript-eslint/visitor-keys@5.62.0:
@@ -6627,7 +6537,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.7.4(@typescript-eslint/parser@6.7.4)(eslint@8.43.0)(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.40.1(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.43.0)(typescript@5.1.3)
       eslint: 8.43.0
     transitivePeerDependencies:
       - supports-color
@@ -6988,19 +6898,6 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /eslint-utils@3.0.0(eslint@8.43.0):
-    resolution:
-      {
-        integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==,
-      }
-    engines: { node: ^10.0.0 || ^12.0.0 || >= 14.0.0 }
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.43.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
-
   /eslint-visitor-keys@1.3.0:
     resolution:
       {
@@ -7015,14 +6912,6 @@ packages:
         integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==,
       }
     engines: { node: '>=10' }
-    dev: true
-
-  /eslint-visitor-keys@3.3.0:
-    resolution:
-      {
-        integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==,
-      }
-    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     dev: true
 
   /eslint-visitor-keys@3.4.1:
@@ -12541,17 +12430,6 @@ packages:
         integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
       }
     hasBin: true
-
-  /semver@7.3.8:
-    resolution:
-      {
-        integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==,
-      }
-    engines: { node: '>=10' }
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
 
   /semver@7.5.4:
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,10 +137,6 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
-    optionalDependencies:
-      react:
-        specifier: ^18
-        version: 18.2.0
     devDependencies:
       '@swc/core':
         specifier: ^1.3.66
@@ -175,6 +171,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.5.0
         version: 29.5.0
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)


### PR DESCRIPTION
Add react as a peer to ensure that there are no transitive dependencies (so pnpm doesn't complain when using isolated modules).

Similar to https://github.com/vercel/speed-insights/pull/45