### PR TITLE
server/track: always consume the response body for a track request

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/server/index.ts
+++ b/packages/web/src/server/index.ts
@@ -134,13 +134,17 @@ export async function track(
       },
       body: JSON.stringify(body),
       method: 'POST',
-    }).catch((err: unknown) => {
-      if (err instanceof Error && 'response' in err) {
-        console.error(err.response);
-      } else {
-        console.error(err);
-      }
-    });
+    })
+      // We want to always consume to body; some cloud providers track fetch concurrency
+      // and may not release the connection until the body is consumed.
+      .then((response) => response.text())
+      .catch((err: unknown) => {
+        if (err instanceof Error && 'response' in err) {
+          console.error(err.response);
+        } else {
+          console.error(err);
+        }
+      });
 
     if (requestContext?.waitUntil) {
       requestContext.waitUntil(promise);


### PR DESCRIPTION
Some cloud providers track fetch concurrency and rely on reading the body to consider a fetch completed.