### PR TITLE
fix: nextjs parallel routes with catchall isn't supported

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/utils.test.ts
+++ b/packages/web/src/utils.test.ts
@@ -145,9 +145,18 @@ describe('utils', () => {
       const input = '/en/us/next-site';
       const params = {
         langs: ['en', 'us'],
-        teamSlug: 'vercel',
       };
       const expected = '/[...langs]/next-site';
+      expect(computeRoute(input, params)).toBe(expected);
+    });
+
+    it('handles array segments and individual segments', () => {
+      const input = '/en/us/next-site';
+      const params = {
+        langs: ['en', 'us'],
+        team: 'next-site',
+      };
+      const expected = '/[...langs]/[team]';
       expect(computeRoute(input, params)).toBe(expected);
     });
 
@@ -170,6 +179,17 @@ describe('utils', () => {
 
       const expected = '/[teamSlug]/tes\\t(test/3.*';
       expect(computeRoute(input, params)).toBe(expected);
+    });
+
+    it('parallel routes where params matched both individually and within arrays', () => {
+      const params = {
+        catchAll: ['m', 'john', 'p', 'shirt'],
+        merchantId: 'john',
+        productSlug: 'shirt',
+      };
+      expect(computeRoute('/m/john/p/shirt', params)).toBe(
+        '/m/[merchantId]/p/[productSlug]'
+      );
     });
 
     describe('edge case handling (same values for multiple params)', () => {

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -84,33 +84,25 @@ export function computeRoute(
 
   let result = pathname;
   try {
-    const keys = Object.entries(pathParams).reduce<{
-      simple: string[];
-      multiple: string[];
-    }>(
-      ({ simple, multiple }, [key, value]) => ({
-        simple: Array.isArray(value) ? simple : [...simple, key],
-        multiple: Array.isArray(value) ? [...multiple, key] : multiple,
-      }),
-      { simple: [], multiple: [] }
-    );
+    const entries = Object.entries(pathParams);
     // simple keys must be handled first
-    for (const key of keys.simple) {
-      const matcher = turnValueToRegExp(pathParams[key] as string);
-      if (matcher.test(result)) {
-        result = result.replace(matcher, `/[${key}]`);
+    for (const [key, value] of entries) {
+      if (!Array.isArray(value)) {
+        const matcher = turnValueToRegExp(value);
+        if (matcher.test(result)) {
+          result = result.replace(matcher, `/[${key}]`);
+        }
       }
     }
     // array values next
-    for (const key of keys.multiple) {
-      const matcher = turnValueToRegExp(
-        (pathParams[key] as string[]).join('/')
-      );
-      if (matcher.test(result)) {
-        result = result.replace(matcher, `/[...${key}]`);
+    for (const [key, value] of entries) {
+      if (Array.isArray(value)) {
+        const matcher = turnValueToRegExp(value.join('/'));
+        if (matcher.test(result)) {
+          result = result.replace(matcher, `/[...${key}]`);
+        }
       }
     }
-
     return result;
   } catch (e) {
     return pathname;


### PR DESCRIPTION
### 🧐 What's in there?

Next.js parallel route isn't fully supported when compute routes for pageviews and custom events.
The unsupported situation is when using a catchall route (`[...catchAll]`) in parallel of individual path parameters (`[teamSlug]`).

With this fix, individual parameter will take precedence over multiple parameters.

### 🧪 How to test?

```shell
cd packages/web
pnpm test
```