### PR TITLE
Make access defensive and fix environment variable reference.

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.5.0-canary.1",
+  "version": "1.5.0-canary.2",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -73,9 +73,9 @@ function inject(
     // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- process doesn't exist in all frameworks
     typeof process !== 'undefined' &&
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
-    process.env?.[basepathVariableName]
+    process.env?.NEXT_PUBLIC_WEB_ANALYTICS_BASEPATH
   ) {
-    script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/speed-insights/vitals`;
+    script.dataset.endpoint = `/${process.env.NEXT_PUBLIC_WEB_ANALYTICS_BASEPATH}/_vercel/speed-insights/vitals`;
   }
   if (props.dsn) {
     script.dataset.dsn = props.dsn;

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -69,7 +69,8 @@ function inject(
   }
   if (props.endpoint) {
     script.dataset.endpoint = props.endpoint;
-  } else if (process.env[basepathVariableName]) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
+  } else if (process?.env?.[basepathVariableName]) {
     script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/insights`;
   }
   if (props.dsn) {

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -69,9 +69,13 @@ function inject(
   }
   if (props.endpoint) {
     script.dataset.endpoint = props.endpoint;
+  } else if (
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- process doesn't exist in all frameworks
+    typeof process !== 'undefined' &&
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process doesn't exist in all frameworks
-  } else if (process?.env?.[basepathVariableName]) {
-    script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/insights`;
+    process.env?.[basepathVariableName]
+  ) {
+    script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/speed-insights/vitals`;
   }
   if (props.dsn) {
     script.dataset.dsn = props.dsn;


### PR DESCRIPTION
`process` may not exist in all frameworks, this ensures things will continue to work as expected.

`process.env[someVar]` works in dev mode but not production, so this switches to `process.env.NEXT_PUBLIC_...`.