### PR TITLE
fix(#157): error when rendering Nuxt component

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.5.0-canary.1",
+  "version": "1.4.1",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -20,8 +20,6 @@ export const DEV_SCRIPT_URL =
   'https://va.vercel-scripts.com/v1/script.debug.js';
 export const PROD_SCRIPT_URL = '/_vercel/insights/script.js';
 
-export const basepathVariableName = 'NEXT_PUBLIC_WEB_ANALYTICS_BASEPATH';
-
 /**
  * Injects the Vercel Web Analytics script into the page head and starts tracking page views. Read more in our [documentation](https://vercel.com/docs/concepts/analytics/package).
  * @param [props] - Analytics options.
@@ -69,8 +67,6 @@ function inject(
   }
   if (props.endpoint) {
     script.dataset.endpoint = props.endpoint;
-  } else if (process.env[basepathVariableName]) {
-    script.dataset.endpoint = `/${process.env[basepathVariableName]}/_vercel/insights`;
   }
   if (props.dsn) {
     script.dataset.dsn = props.dsn;

--- a/packages/web/src/vue/create-component.ts
+++ b/packages/web/src/vue/create-component.ts
@@ -19,7 +19,7 @@ export function createComponent(
         framework,
       });
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- route is undefined for barebone vue project.
-      if (route && window) {
+      if (route && typeof window !== 'undefined') {
         const changeRoute = (): void => {
           pageview({
             route: computeRoute(route.path, route.params),


### PR DESCRIPTION
### 🖖 What's in there?

A fix for #157.

### 🤺 How to test?

It's actually not possible to reproduce the issue with the example app. Possibly because of intra-monorepo depdencies.
To reproduce the issue:
1. change dependency in `apps/nuxt/package.json`: `"@vercel/analytics": "1.4.0"``
1. `pnpm -F nuxt dev`, then browse to the app: you'll see the error.

### 🔬Notes to reviewers

Since this is an urgent bug fix, I've [reverted](https://github.com/vercel/analytics/commit/68d0d13d60e7d0672a33c1a1b3f0624e1b137ecd) @emspishak's changes from 1.5.0-canary.1, but we have #158 in the pipe for covering this new feature as well.