### PR TITLE
fix: next/jest does not support import.meta

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "1.5.0-canary.2",
+  "version": "1.5.0-canary.3",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",

--- a/packages/web/src/astro/index.astro
+++ b/packages/web/src/astro/index.astro
@@ -15,6 +15,19 @@ const paramsStr = JSON.stringify(Astro.params);
 <script>
   import { inject, pageview, computeRoute } from '../index.mjs';
 
+  function getBasePath(): string | undefined {
+    // !! important !!
+    // do not access env variables using import.meta.env[varname]
+    // some bundles won't replace the value at build time.
+    try {
+      return import.meta.env.PUBLIC_VERCEL_OBSERVABILITY_BASEPATH as
+        | string
+        | undefined;
+    } catch {
+      // do nothing
+    }
+  }
+
   customElements.define(
     'vercel-analytics',
     class VercelAnalytics extends HTMLElement {
@@ -27,6 +40,7 @@ const paramsStr = JSON.stringify(Astro.params);
             ...props,
             disableAutoTrack: true,
             framework: 'astro',
+            basePath: getBasePath(),
             beforeSend: window.webAnalyticsBeforeSend,
           });
           const path = this.dataset.pathname;

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -14,7 +14,6 @@ import {
   isDevelopment,
   isProduction,
   computeRoute,
-  getBasePath,
   getScriptSrc,
 } from './utils';
 
@@ -34,6 +33,7 @@ function inject(
   props: AnalyticsProps & {
     framework?: string;
     disableAutoTrack?: boolean;
+    basePath?: string;
   } = {
     debug: true,
   }
@@ -62,11 +62,10 @@ function inject(
   if (props.disableAutoTrack) {
     script.dataset.disableAutoTrack = '1';
   }
-  const basePath = getBasePath();
   if (props.endpoint) {
     script.dataset.endpoint = props.endpoint;
-  } else if (basePath) {
-    script.dataset.endpoint = `${basePath}/insights`;
+  } else if (props.basePath) {
+    script.dataset.endpoint = `${props.basePath}/insights`;
   }
   if (props.dsn) {
     script.dataset.dsn = props.dsn;

--- a/packages/web/src/nextjs/index.tsx
+++ b/packages/web/src/nextjs/index.tsx
@@ -2,14 +2,20 @@
 import React, { Suspense, type ReactNode } from 'react';
 import { Analytics as AnalyticsScript } from '../react';
 import type { AnalyticsProps, BeforeSend, BeforeSendEvent } from '../types';
-import { useRoute } from './utils';
+import { getBasePath, useRoute } from './utils';
 
 type Props = Omit<AnalyticsProps, 'route' | 'disableAutoTrack'>;
 
 function AnalyticsComponent(props: Props): ReactNode {
   const { route, path } = useRoute();
   return (
-    <AnalyticsScript path={path} route={route} {...props} framework="next" />
+    <AnalyticsScript
+      path={path}
+      route={route}
+      {...props}
+      basePath={getBasePath()}
+      framework="next"
+    />
   );
 }
 

--- a/packages/web/src/nextjs/utils.test.ts
+++ b/packages/web/src/nextjs/utils.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { getBasePath } from './utils';
+
+describe('getBasePath()', () => {
+  const processSave = { ...process };
+  const envSave = { ...process.env };
+
+  afterEach(() => {
+    global.process = { ...processSave };
+    process.env = { ...envSave };
+  });
+
+  it('returns null without process', () => {
+    // @ts-expect-error -- yes, we want to completely drop process for this test!!
+    global.process = undefined;
+    expect(getBasePath()).toBeUndefined();
+  });
+
+  it('returns null without process.env', () => {
+    // @ts-expect-error -- yes, we want to completely drop process.env for this test!!
+    process.env = undefined;
+    expect(getBasePath()).toBeUndefined();
+  });
+
+  it('returns basepath set for Nextjs', () => {
+    const basepath = `/_vercel-${Math.random()}/insights`;
+    process.env.NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH = basepath;
+    expect(getBasePath()).toBe(basepath);
+  });
+});

--- a/packages/web/src/nextjs/utils.ts
+++ b/packages/web/src/nextjs/utils.ts
@@ -21,3 +21,14 @@ export const useRoute = (): {
     : Object.fromEntries(searchParams.entries());
   return { route: computeRoute(path, finalParams), path };
 };
+
+export function getBasePath(): string | undefined {
+  // !! important !!
+  // do not access env variables using process.env[varname]
+  // some bundles won't replace the value at build time.
+  // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- we can't use optionnal here, it'll break if process does not exist.
+  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
+    return undefined;
+  }
+  return process.env.NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH;
+}

--- a/packages/web/src/react/index.test.tsx
+++ b/packages/web/src/react/index.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
-import { Analytics, track } from './react';
-import type { AllowedPropertyValues, AnalyticsProps, Mode } from './types';
+import type { AllowedPropertyValues, AnalyticsProps, Mode } from '../types';
+import { Analytics, track } from './index';
 
 describe('<Analytics />', () => {
   afterEach(() => {

--- a/packages/web/src/react/index.tsx
+++ b/packages/web/src/react/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useEffect } from 'react';
-import { inject, track, pageview } from './generic';
-import type { AnalyticsProps, BeforeSend, BeforeSendEvent } from './types';
+import { inject, track, pageview } from '../generic';
+import type { AnalyticsProps, BeforeSend, BeforeSendEvent } from '../types';
+import { getBasePath } from './utils';
 
 /**
  * Injects the Vercel Web Analytics script into the page head and starts tracking page views. Read more in our [documentation](https://vercel.com/docs/concepts/analytics/package).
@@ -31,6 +32,7 @@ function Analytics(
     framework?: string;
     route?: string | null;
     path?: string | null;
+    basePath?: string;
   }
 ): null {
   useEffect(() => {
@@ -43,6 +45,7 @@ function Analytics(
   useEffect(() => {
     inject({
       framework: props.framework || 'react',
+      basePath: props.basePath ?? getBasePath(),
       ...(props.route !== undefined && { disableAutoTrack: true }),
       ...props,
     });

--- a/packages/web/src/react/utils.test.ts
+++ b/packages/web/src/react/utils.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { getBasePath } from './utils';
+
+describe('getBasePath()', () => {
+  const processSave = { ...process };
+  const envSave = { ...process.env };
+
+  afterEach(() => {
+    global.process = { ...processSave };
+    process.env = { ...envSave };
+  });
+
+  it('returns null without process', () => {
+    // @ts-expect-error -- yes, we want to completely drop process for this test!!
+    global.process = undefined;
+    expect(getBasePath()).toBeUndefined();
+  });
+
+  it('returns null without process.env', () => {
+    // @ts-expect-error -- yes, we want to completely drop process.env for this test!!
+    process.env = undefined;
+    expect(getBasePath()).toBeUndefined();
+  });
+
+  it('returns basepath set for CRA', () => {
+    const basepath = `/_vercel-${Math.random()}/insights`;
+    process.env.REACT_APP_VERCEL_OBSERVABILITY_BASEPATH = basepath;
+    expect(getBasePath()).toBe(basepath);
+  });
+});

--- a/packages/web/src/react/utils.ts
+++ b/packages/web/src/react/utils.ts
@@ -1,0 +1,10 @@
+export function getBasePath(): string | undefined {
+  // !! important !!
+  // do not access env variables using process.env[varname]
+  // some bundles won't replace the value at build time.
+  // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- we can't use optionnal here, it'll break if process does not exist.
+  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
+    return undefined;
+  }
+  return process.env.REACT_APP_VERCEL_OBSERVABILITY_BASEPATH;
+}

--- a/packages/web/src/remix/index.tsx
+++ b/packages/web/src/remix/index.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { Analytics as AnalyticsScript } from '../react';
 import type { AnalyticsProps, BeforeSend, BeforeSendEvent } from '../types';
-import { useRoute } from './utils';
+import { getBasePath, useRoute } from './utils';
 
 export function Analytics(props: Omit<AnalyticsProps, 'route'>): JSX.Element {
-  return <AnalyticsScript {...useRoute()} {...props} framework="remix" />;
+  return (
+    <AnalyticsScript
+      {...useRoute()}
+      {...props}
+      basePath={getBasePath()}
+      framework="remix"
+    />
+  );
 }
 export type { AnalyticsProps, BeforeSend, BeforeSendEvent };

--- a/packages/web/src/remix/utils.test.ts
+++ b/packages/web/src/remix/utils.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { getBasePath } from './utils';
+
+describe('getBasePath()', () => {
+  const processSave = { ...process };
+  const envSave = { ...process.env };
+
+  afterEach(() => {
+    global.process = { ...processSave };
+    process.env = { ...envSave };
+  });
+
+  it('returns basepath set for Remix', () => {
+    const basepath = `/_vercel-${Math.random()}/insights`;
+    import.meta.env.VITE_VERCEL_OBSERVABILITY_BASEPATH = basepath;
+    expect(getBasePath()).toBe(basepath);
+  });
+
+  it('returns null without import.meta', () => {
+    // @ts-expect-error -- yes, we want to completely drop import.meta.env for this test!!
+    import.meta.env = undefined;
+    expect(getBasePath()).toBeUndefined();
+  });
+});

--- a/packages/web/src/sveltekit/index.ts
+++ b/packages/web/src/sveltekit/index.ts
@@ -1,5 +1,6 @@
 import { inject, pageview, track } from '../generic';
 import type { AnalyticsProps, BeforeSend, BeforeSendEvent } from '../types';
+import { getBasePath } from './utils';
 import { page } from '$app/stores';
 import { browser } from '$app/environment';
 import type {} from '@sveltejs/kit';
@@ -8,6 +9,7 @@ function injectAnalytics(props: Omit<AnalyticsProps, 'framework'> = {}): void {
   if (browser) {
     inject({
       ...props,
+      basePath: getBasePath(),
       disableAutoTrack: true,
       framework: 'sveltekit',
     });

--- a/packages/web/src/sveltekit/utils.test.ts
+++ b/packages/web/src/sveltekit/utils.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { getBasePath } from './utils';
+
+describe('getBasePath()', () => {
+  const processSave = { ...process };
+  const envSave = { ...process.env };
+
+  afterEach(() => {
+    global.process = { ...processSave };
+    process.env = { ...envSave };
+  });
+
+  it('returns basepath set for Sveltekit', () => {
+    const basepath = `/_vercel-${Math.random()}/insights`;
+    import.meta.env.VITE_VERCEL_OBSERVABILITY_BASEPATH = basepath;
+    expect(getBasePath()).toBe(basepath);
+  });
+
+  it('returns null without import.meta', () => {
+    // @ts-expect-error -- yes, we want to completely drop import.meta.env for this test!!
+    import.meta.env = undefined;
+    expect(getBasePath()).toBeUndefined();
+  });
+});

--- a/packages/web/src/sveltekit/utils.ts
+++ b/packages/web/src/sveltekit/utils.ts
@@ -1,12 +1,3 @@
-import { useLocation, useParams } from '@remix-run/react';
-import { computeRoute } from '../utils';
-
-export const useRoute = (): { route: string | null; path: string } => {
-  const params = useParams();
-  const { pathname: path } = useLocation();
-  return { route: computeRoute(path, params as never), path };
-};
-
 export function getBasePath(): string | undefined {
   // !! important !!
   // do not access env variables using import.meta.env[varname]

--- a/packages/web/src/utils.test.ts
+++ b/packages/web/src/utils.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeAll, describe, it, expect } from 'vitest';
 import {
   computeRoute,
-  getBasePath,
   getMode,
   getScriptSrc,
   parseProperties,
@@ -223,58 +222,6 @@ describe('utils', () => {
     });
   });
 
-  describe('getBasePath()', () => {
-    const processSave = { ...process };
-    const envSave = { ...process.env };
-
-    afterEach(() => {
-      global.process = { ...processSave };
-      process.env = { ...envSave };
-    });
-
-    it('returns null without process', () => {
-      // @ts-expect-error -- yes, we want to completely drop process for this test!!
-      global.process = undefined;
-      expect(getBasePath()).toBe(null);
-    });
-
-    it('returns null without process.env', () => {
-      // @ts-expect-error -- yes, we want to completely drop process.env for this test!!
-      process.env = undefined;
-      expect(getBasePath()).toBe(null);
-    });
-
-    it('returns basepath set for Nextjs', () => {
-      const basepath = `/_vercel-${Math.random()}/insights`;
-      process.env.NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH = basepath;
-      expect(getBasePath()).toBe(basepath);
-    });
-
-    it('returns basepath set for Sveltekit, Nuxt, Vue, Remix', () => {
-      const basepath = `/_vercel-${Math.random()}/insights`;
-      import.meta.env.VITE_VERCEL_OBSERVABILITY_BASEPATH = basepath;
-      expect(getBasePath()).toBe(basepath);
-    });
-
-    it('returns basepath set for Astro', () => {
-      const basepath = `/_vercel-${Math.random()}/insights`;
-      import.meta.env.PUBLIC_VERCEL_OBSERVABILITY_BASEPATH = basepath;
-      expect(getBasePath()).toBe(basepath);
-    });
-
-    it('returns basepath set for CRA', () => {
-      const basepath = `/_vercel-${Math.random()}/insights`;
-      process.env.REACT_APP_VERCEL_OBSERVABILITY_BASEPATH = basepath;
-      expect(getBasePath()).toBe(basepath);
-    });
-
-    it('returns null without import.meta', () => {
-      // @ts-expect-error -- yes, we want to completely drop import.meta.env for this test!!
-      import.meta.env = undefined;
-      expect(getBasePath()).toBe(null);
-    });
-  });
-
   describe('getScriptSrc()', () => {
     const envSave = { ...process.env };
 
@@ -301,9 +248,8 @@ describe('utils', () => {
     });
 
     it('returns base path in production', () => {
-      const basepath = `/_vercel-${Math.random()}`;
-      process.env.NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH = basepath;
-      expect(getScriptSrc({})).toBe(`${basepath}/insights/script.js`);
+      const basePath = `/_vercel-${Math.random()}`;
+      expect(getScriptSrc({ basePath })).toBe(`${basePath}/insights/script.js`);
     });
 
     it('returns the specified prop in production', () => {

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -117,57 +117,17 @@ function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-export function getBasePath(): null | string {
-  // !! important !!
-  // do not access env variables using process.env[varname] or import.meta.env[varname].
-  // some bundles won't replace the value at build time.
-
-  // vite-powered apps (sveltekit, nuxt, vue, astro, remix)
-  try {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error -- only TS during build time will complain.
-    // @ts-ignore -- Rollup will fail to generate d.ts because it doesn't know import.meta.env.
-    const viteValue = import.meta.env
-      .VITE_VERCEL_OBSERVABILITY_BASEPATH as string;
-    if (viteValue) {
-      return viteValue;
-    }
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error -- only TS during build time will complain.
-    // @ts-ignore -- Rollup will fail to generate d.ts because it doesn't know import.meta.env.
-    const astroValue = import.meta.env
-      .PUBLIC_VERCEL_OBSERVABILITY_BASEPATH as string;
-    if (astroValue) {
-      return astroValue;
-    }
-  } catch {
-    // do nothing
-  }
-  // eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- we can't use optional here, it'll break if process does not exist.
-  if (typeof process === 'undefined' || typeof process.env === 'undefined') {
-    return null;
-  }
-  // nextjs apps
-  const nextValue = process.env.NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH;
-  if (nextValue) {
-    return nextValue;
-  }
-  // create-react-app
-  const craValue = process.env.REACT_APP_VERCEL_OBSERVABILITY_BASEPATH;
-  if (craValue) {
-    return craValue;
-  }
-  return null;
-}
-
-export function getScriptSrc(props: AnalyticsProps): string {
+export function getScriptSrc(
+  props: AnalyticsProps & { basePath?: string }
+): string {
   if (props.scriptSrc) {
     return props.scriptSrc;
   }
   if (isDevelopment()) {
     return 'https://va.vercel-scripts.com/v1/script.debug.js';
   }
-  const basePath = getBasePath();
-  if (basePath) {
-    return `${basePath}/insights/script.js`;
+  if (props.basePath) {
+    return `${props.basePath}/insights/script.js`;
   }
   return '/_vercel/insights/script.js';
 }

--- a/packages/web/src/vue/create-component.ts
+++ b/packages/web/src/vue/create-component.ts
@@ -3,6 +3,7 @@ import { defineComponent, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { inject, pageview, type AnalyticsProps } from '../generic';
 import { computeRoute } from '../utils';
+import { getBasePath } from './utils';
 
 export function createComponent(
   framework = 'vue'
@@ -14,6 +15,7 @@ export function createComponent(
       const route = useRoute();
       inject({
         ...props,
+        basePath: getBasePath(),
         // keep auto-tracking unless we have route support (Nuxt or vue-router).
         disableAutoTrack: Boolean(route),
         framework,

--- a/packages/web/src/vue/utils.test.ts
+++ b/packages/web/src/vue/utils.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { getBasePath } from './utils';
+
+describe('getBasePath()', () => {
+  const processSave = { ...process };
+  const envSave = { ...process.env };
+
+  afterEach(() => {
+    global.process = { ...processSave };
+    process.env = { ...envSave };
+  });
+
+  it('returns basepath set for Vue', () => {
+    const basepath = `/_vercel-${Math.random()}/insights`;
+    import.meta.env.VITE_VERCEL_OBSERVABILITY_BASEPATH = basepath;
+    expect(getBasePath()).toBe(basepath);
+  });
+
+  it('returns null without import.meta', () => {
+    // @ts-expect-error -- yes, we want to completely drop import.meta.env for this test!!
+    import.meta.env = undefined;
+    expect(getBasePath()).toBeUndefined();
+  });
+});

--- a/packages/web/src/vue/utils.ts
+++ b/packages/web/src/vue/utils.ts
@@ -1,12 +1,3 @@
-import { useLocation, useParams } from '@remix-run/react';
-import { computeRoute } from '../utils';
-
-export const useRoute = (): { route: string | null; path: string } => {
-  const params = useParams();
-  const { pathname: path } = useLocation();
-  return { route: computeRoute(path, params as never), path };
-};
-
 export function getBasePath(): string | undefined {
   // !! important !!
   // do not access env variables using import.meta.env[varname]

--- a/packages/web/tsup.config.js
+++ b/packages/web/tsup.config.js
@@ -36,7 +36,7 @@ export default defineConfig([
   {
     ...cfg,
     entry: {
-      index: 'src/react.tsx',
+      index: 'src/react/index.tsx',
     },
     external: ['react'],
     outDir: 'dist/react',


### PR DESCRIPTION
### 🖖 What's in there?

We found out our package breaks Next.js test, because its Jest configuration doesn't support `import.meta`.
This PR fixes it.

### 🤺 How to test?

To reproduce locally, and set custom basepath:
```shell
pnpm i && pnpm -F @vercel/analytics build 
```

Then:
1. For Nextjs 14 app
   ```shell
   NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH="/abc" pnpm -F nextjs build
   pnpm -F nextjs start
   ```
   browse to http://localhost:3000 and check your console: it's trying (and failing) to download `/abc/insights/script.js`

1. For Nextjs 15 app
   ```shell
   NEXT_PUBLIC_VERCEL_OBSERVABILITY_BASEPATH="/def" pnpm -F nextjs-15 build
   pnpm -F nextjs-15 start
   ```
   browse to http://localhost:3000 and check your console: it's trying (and failing) to download `/def/insights/script.js`

1. For Sveltekit app
   ```shell
   VITE_VERCEL_OBSERVABILITY_BASEPATH="/hij" pnpm -F sveltekit build
   pnpm -F sveltekit preview
   ```
   browse to http://localhost:4173 and check your console: it's trying (and failing) to download `/hij/insights/script.js`

1. For vue app
   ```shell
   VITE_VERCEL_OBSERVABILITY_BASEPATH="/klm" pnpm -F vue build
   pnpm -F vue preview
   ```
   browse to http://localhost:4173 and check your console: it's trying (and failing) to download `/klm/insights/script.js`

1. For nuxt app
   ```shell
   VITE_VERCEL_OBSERVABILITY_BASEPATH="/nop" pnpm -F nuxt build
   pnpm -F nuxt preview
   ```
   browse to http://localhost:3000 and check your console: it's trying (and failing) to download `/nop/insights/script.js`

1. For remix app
   ```shell
   VITE_VERCEL_OBSERVABILITY_BASEPATH="/qrs" pnpm -F remix build
   pnpm -F remix start
   ```
   browse to http://localhost:3000 and check your console: it's trying (and failing) to download `/qrs/insights/script.js`

1. For astro app
   ```shell
   PUBLIC_VERCEL_OBSERVABILITY_BASEPATH="/tuv" pnpm -F astro build
   pnpm -F astro preview
   ```
   browse to http://localhost:4321 and check your console: it's trying (and failing) to download `/tuv/insights/script.js`

There is no example for CRA.

### 🔬Notes to reviewers

Rather than altering jest configuration for next, I've split the `getBasePath()` function so each framework has its own implementation.

I've moved the React component into its own folder as we do for speed-insights.

### 🔗 Related PRs

- #158 