### PR TITLE
Add `undefined` to AllowedPropertyValues type

### DIFF
--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -10,7 +10,12 @@ interface CustomEvent {
 export type BeforeSendEvent = PageViewEvent | CustomEvent;
 
 export type Mode = 'auto' | 'development' | 'production';
-export type AllowedPropertyValues = string | number | boolean | null;
+export type AllowedPropertyValues =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
 
 export type BeforeSend = (event: BeforeSendEvent) => BeforeSendEvent | null;
 


### PR DESCRIPTION
Make the type used inside `track` more forgiving.