### PR TITLE
fix(release): add missing space in pnpm -F flag

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: latest
+          version: 2.3.10
       - name: Run Biome
         run: biome ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
         uses: ./.github/composite-actions/install
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
+        with:
+          version: 2.3.10
       - name: Run Biome
         run: biome ci
       - name: Build


### PR DESCRIPTION
The stable publish step on line 25 of `release.yml` was missing a space between `-F` and `@vercel/analytics`, causing `pnpm` to error with `Unknown option: 'F@vercel/analytics'`. This caused the v2.0.0 NPM publish to fail.

```
# before
pnpm -F@vercel/analytics publish --no-git-checks

# after
pnpm -F @vercel/analytics publish --no-git-checks
```

After merging, re-trigger the release by re-publishing the v2.0.0 GitHub Release.