### PR TITLE
chore: bump version to v2.0.1

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/analytics",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Gain real-time traffic insights with Vercel Web Analytics",
   "keywords": [
     "analytics",


### PR DESCRIPTION
## Summary
- bump @vercel/analytics from 2.0.0 to 2.0.1 in packages/web/package.json