### PR TITLE
fix(next): export track from Next.js binding and fix hard-refresh event loss

### DIFF
--- a/apps/nextjs-15/src/app/blog/[slug]/page.tsx
+++ b/apps/nextjs-15/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import styles from '../layout.module.css';
 
 export default async function BlogPage({
   params,
@@ -7,10 +8,15 @@ export default async function BlogPage({
 }) {
   const { slug } = await params;
   return (
-    <div>
-      <h2>{slug}</h2>
-
-      <Link href="/blog">Back to blog</Link>
-    </div>
+    <>
+      <span className={styles.badge}>Blog</span>
+      <h1>{slug.replace(/-/g, ' ')}</h1>
+      <p className={styles.description}>
+        This is the post content for &ldquo;{slug}&rdquo;.
+      </p>
+      <Link className={styles.back} href="/blog">
+        All posts
+      </Link>
+    </>
   );
 }

--- a/apps/nextjs-15/src/app/blog/layout.module.css
+++ b/apps/nextjs-15/src/app/blog/layout.module.css
@@ -10,25 +10,60 @@
 .main {
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 32px;
   max-width: 480px;
   width: 100%;
 }
 
-.main h1 {
-  font-size: 32px;
-  font-weight: 600;
-  letter-spacing: -0.03em;
-  line-height: 1.2;
+.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.4);
+  text-decoration: none;
+  transition: color 0.15s;
 }
 
-.nav {
+.back::before {
+  content: "←";
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.4);
+}
+
+.badge::before {
+  content: "";
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3b82f6;
+}
+
+.main h1 {
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.posts {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.link {
+.post {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -42,30 +77,53 @@
     border-color 0.15s;
 }
 
-.link::after {
+.post::after {
   content: "→";
   opacity: 0.4;
 }
 
+.description {
+  font-size: 15px;
+  line-height: 1.6;
+  color: rgba(0, 0, 0, 0.5);
+  margin: 0;
+}
+
 @media (hover: hover) and (pointer: fine) {
-  .link:hover {
+  .back:hover {
+    color: var(--foreground);
+  }
+
+  .post:hover {
     background: rgba(0, 0, 0, 0.04);
     border-color: rgba(0, 0, 0, 0.15);
   }
 
-  .link:hover::after {
+  .post:hover::after {
     opacity: 1;
   }
 }
 
 @media (prefers-color-scheme: dark) {
-  .link {
+  .back {
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .badge {
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .post {
     border-color: rgba(255, 255, 255, 0.1);
   }
 
-  .link:hover {
+  .post:hover {
     background: rgba(255, 255, 255, 0.05);
     border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .description {
+    color: rgba(255, 255, 255, 0.5);
   }
 }
 

--- a/apps/nextjs-15/src/app/blog/layout.tsx
+++ b/apps/nextjs-15/src/app/blog/layout.tsx
@@ -1,12 +1,15 @@
 import Link from 'next/link';
+import styles from './layout.module.css';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div>
-      <Link href="/blog/my-first-blogpost">My first blog post</Link>&nbsp;
-      <Link href="/blog/new-feature-release">Feature just got released</Link>
-      <br />
-      <div>{children}</div>
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <Link className={styles.back} href="/">
+          Home
+        </Link>
+        {children}
+      </main>
     </div>
   );
 }

--- a/apps/nextjs-15/src/app/blog/page.tsx
+++ b/apps/nextjs-15/src/app/blog/page.tsx
@@ -1,3 +1,19 @@
+import Link from 'next/link';
+import styles from './layout.module.css';
+
 export default function Blog() {
-  return <div>Welcome to the blog</div>;
+  return (
+    <>
+      <span className={styles.badge}>Blog</span>
+      <h1>Posts</h1>
+      <nav className={styles.posts}>
+        <Link className={styles.post} href="/blog/my-first-blogpost">
+          My first blog post
+        </Link>
+        <Link className={styles.post} href="/blog/new-feature-release">
+          Feature just got released
+        </Link>
+      </nav>
+    </>
+  );
 }

--- a/apps/nextjs-15/src/app/experiment/exposure-tracker.tsx
+++ b/apps/nextjs-15/src/app/experiment/exposure-tracker.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { track } from '@vercel/analytics/next';
+import { useEffect } from 'react';
+import styles from './page.module.css';
+
+let tracked = false;
+
+export function ExposureTracker() {
+  useEffect(() => {
+    if (tracked) return;
+    tracked = true;
+    track('exposure');
+  }, []);
+
+  return (
+    <button
+      type="button"
+      className={styles.button}
+      onClick={() => track('click_cta')}
+    >
+      Try it out
+    </button>
+  );
+}

--- a/apps/nextjs-15/src/app/experiment/page.module.css
+++ b/apps/nextjs-15/src/app/experiment/page.module.css
@@ -1,0 +1,113 @@
+.page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100svh;
+  padding: 80px;
+  font-family: var(--font-geist-sans);
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  max-width: 480px;
+  width: 100%;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.4);
+}
+
+.badge::before {
+  content: "";
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #22c55e;
+}
+
+.main h1 {
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.description {
+  font-size: 15px;
+  line-height: 1.6;
+  color: rgba(0, 0, 0, 0.5);
+  margin: 0;
+}
+
+.button {
+  align-self: flex-start;
+  appearance: none;
+  background: var(--foreground);
+  color: var(--background);
+  border: none;
+  border-radius: 10px;
+  padding: 12px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .button:hover {
+    opacity: 0.8;
+  }
+}
+
+.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.4);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.back::before {
+  content: "←";
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .back:hover {
+    color: var(--foreground);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .badge {
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .description {
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  .back {
+    color: rgba(255, 255, 255, 0.4);
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 32px;
+    align-items: flex-start;
+    padding-top: 64px;
+  }
+}

--- a/apps/nextjs-15/src/app/experiment/page.tsx
+++ b/apps/nextjs-15/src/app/experiment/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { ExposureTracker } from './exposure-tracker';
+import styles from './page.module.css';
+
+export default function ExperimentPage() {
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <Link className={styles.back} href="/">
+          Home
+        </Link>
+        <span className={styles.badge}>Experiment</span>
+        <h1>See what we&apos;re testing</h1>
+        <p className={styles.description}>
+          This page is part of an active experiment. Your visit has been
+          recorded as an exposure, and you can interact below to track
+          additional events.
+        </p>
+        <ExposureTracker />
+      </main>
+    </div>
+  );
+}

--- a/apps/nextjs-15/src/app/page.tsx
+++ b/apps/nextjs-15/src/app/page.tsx
@@ -1,95 +1,20 @@
-import Image from 'next/image';
+import Link from 'next/link';
 import styles from './page.module.css';
 
 export default function Home() {
   return (
     <div className={styles.page}>
       <main className={styles.main}>
-        <Image
-          className={styles.logo}
-          src="https://nextjs.org/icons/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol>
-          <li>
-            Get started by editing <code>src/app/page.tsx</code>.
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className={styles.ctas}>
-          <a
-            className={styles.primary}
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className={styles.logo}
-              src="https://nextjs.org/icons/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.secondary}
-          >
-            Read our docs
-          </a>
-        </div>
+        <h1>Next.js 15 Analytics Demo</h1>
+        <nav className={styles.nav}>
+          <Link className={styles.link} href="/blog">
+            Blog
+          </Link>
+          <Link className={styles.link} href="/experiment">
+            Experiment
+          </Link>
+        </nav>
       </main>
-      <footer className={styles.footer}>
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
   );
 }

--- a/apps/nextjs/e2e/development/beforeSend.spec.ts
+++ b/apps/nextjs/e2e/development/beforeSend.spec.ts
@@ -35,13 +35,13 @@ test.describe('beforeSend', () => {
 
     expect(
       messages.find((m) =>
-        m.includes('[pageview] http://localhost:3000/before-send/first'),
+        m.includes('[view] http://localhost:3000/before-send/first'),
       ),
     ).toBeDefined();
     expect(
       messages.find((m) =>
         m.includes(
-          '[pageview] http://localhost:3000/before-send/second?secret=REDACTED',
+          '[view] http://localhost:3000/before-send/second?secret=REDACTED',
         ),
       ),
     ).toBeDefined();

--- a/apps/nextjs/e2e/development/pageview.spec.ts
+++ b/apps/nextjs/e2e/development/pageview.spec.ts
@@ -35,12 +35,12 @@ test.describe('pageview', () => {
 
     expect(
       messages.find((m) =>
-        m.includes('[pageview] http://localhost:3000/navigation/first'),
+        m.includes('[view] http://localhost:3000/navigation/first'),
       ),
     ).toBeDefined();
     expect(
       messages.find((m) =>
-        m.includes('[pageview] http://localhost:3000/navigation/second'),
+        m.includes('[view] http://localhost:3000/navigation/second'),
       ),
     ).toBeDefined();
   });

--- a/apps/nextjs/e2e/utils.ts
+++ b/apps/nextjs/e2e/utils.ts
@@ -10,15 +10,13 @@ export async function useMockForProductionScript(props: {
       "Object.defineProperty(navigator, 'webdriver', { get() { return undefined }})",
   });
 
-  await props.page.route('**/_vercel/insights/script.js', async (route, _) => {
-    return route.fulfill({
-      status: 301,
-      headers: {
-        location: props.debug
-          ? 'https://cdn.vercel-insights.com/v1/script.debug.js'
-          : 'https://cdn.vercel-insights.com/v1/script.js',
-      },
+  await props.page.route('**/_vercel/insights/script.js', async (route) => {
+    const response = await route.fetch({
+      url: props.debug
+        ? 'https://va.vercel-scripts.com/v1/script.debug.js'
+        : 'https://va.vercel-scripts.com/v1/script.js',
     });
+    return route.fulfill({ response });
   });
 
   await props.page.route('**/_vercel/insights/view', async (route, request) => {

--- a/packages/web/src/generic.test.ts
+++ b/packages/web/src/generic.test.ts
@@ -138,6 +138,22 @@ describe.each([
     });
   });
 
+  describe('track before inject', () => {
+    beforeEach(() => {
+      // simulate a fresh page load where inject hasn't run yet
+      window.va = undefined;
+      window.vaq = undefined;
+    });
+
+    it('initializes the queue and buffers events with properties', () => {
+      track('exposure', { variant: 'A' });
+      expect(window.vaq?.[0]).toEqual([
+        'event',
+        { name: 'exposure', data: { variant: 'A' } },
+      ]);
+    });
+  });
+
   describe('track custom events', () => {
     beforeEach(() => {
       // reset the internal queue before every test

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -89,6 +89,10 @@ function track(
 
     return;
   }
+  // in case the track function is invoked even before inject
+  // (can happen because react renders children before their parents)
+  // make sure we do not miss them.
+  initQueue();
 
   if (!properties) {
     window.va?.('event', { name, options });

--- a/packages/web/src/nextjs/index.tsx
+++ b/packages/web/src/nextjs/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { type ReactNode, Suspense } from 'react';
+import { track } from '../generic';
 import { Analytics as AnalyticsScript } from '../react';
 import type { AnalyticsProps, BeforeSend, BeforeSendEvent } from '../types';
 import { getBasePath, getConfigString, useRoute } from './utils';
@@ -29,4 +30,5 @@ export function Analytics(props: Props): null {
   ) as never;
 }
 
+export { track };
 export type { AnalyticsProps, BeforeSend, BeforeSendEvent };

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,14 +1,3 @@
-interface PageViewEvent {
-  type: 'pageview';
-  url: string;
-}
-interface CustomEvent {
-  type: 'event';
-  url: string;
-}
-
-export type BeforeSendEvent = PageViewEvent | CustomEvent;
-
 export type Mode = 'auto' | 'development' | 'production';
 export type AllowedPropertyValues =
   | string
@@ -16,6 +5,30 @@ export type AllowedPropertyValues =
   | boolean
   | null
   | undefined;
+
+export type PlainFlags = Record<string, unknown>;
+export type FlagsDataInput = (string | PlainFlags)[] | PlainFlags;
+
+export type TrackEventPayload = {
+  name: string;
+  data?: Record<string, AllowedPropertyValues>;
+  options?: {
+    flags?: FlagsDataInput;
+  };
+};
+
+interface PageViewEvent {
+  type: 'pageview';
+  url: string;
+}
+
+interface CustomEvent {
+  type: 'event';
+  url: string;
+  payload: TrackEventPayload;
+}
+
+export type BeforeSendEvent = PageViewEvent | CustomEvent;
 
 export type BeforeSend = (event: BeforeSendEvent) => BeforeSendEvent | null;
 
@@ -53,6 +66,3 @@ declare global {
     webAnalyticsBeforeSend?: BeforeSend;
   }
 }
-
-export type PlainFlags = Record<string, unknown>;
-export type FlagsDataInput = (string | PlainFlags)[] | PlainFlags;


### PR DESCRIPTION
## 🖖🏻 What's in there?

- **Export `track` from `@vercel/analytics/next`** — the Next.js binding was missing a `track` export, requiring users to import it from a the react entry point.

- **Fix `track()` silently dropping events on hard refresh** — when `track()` was called before `inject()` ran (which happens on hard refresh because React runs children's `useEffect`s before parents'), `window.va` was still `undefined` and the optional chain `?.` silently swallowed the event. Fixed by calling `initQueue()` at the start of `track()` so events are always buffered, regardless of initialization order.

- **Type improvements in `types.ts`** — reorganized type declarations and added `TrackEventPayload` and a `payload` field on `CustomEvent` in `BeforeSendEvent` for better typing of the `beforeSend` callback.

## 🔬 Notes to reviewers

I made an Experiment page in the next-15 demo app to illustrate the lost tracked events. And slightly improved the look of these test pages.

Also fixed the damn e2e tests that were failing since ages