### PR TITLE
fix(ci): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -23,8 +26,8 @@ jobs:
       - run: pnpm -F @vercel/analytics publish --tag beta --no-git-checks
         if: github.event.release.prerelease == true
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          NPM_CONFIG_PROVENANCE: 'true'
       - run: pnpm -F @vercel/analytics publish --no-git-checks
         if: github.event.release.prerelease == false
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,5 @@ jobs:
         run: pnpm -F @vercel/analytics build
       - run: pnpm -F @vercel/analytics publish --tag beta --no-git-checks
         if: github.event.release.prerelease == true
-        env:
-          NPM_CONFIG_PROVENANCE: 'true'
       - run: pnpm -F @vercel/analytics publish --no-git-checks
         if: github.event.release.prerelease == false
-        env:
-          NPM_CONFIG_PROVENANCE: 'true'

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,9 @@
     "directory": "packages/web"
   },
   "license": "MIT",
+  "publishConfig": {
+    "provenance": true
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
## Why

The release job authenticated to npm with `NPM_TOKEN_ELEVATED`. That elevated token can no longer be used (permissions revoked), so publishing is broken.

This switches publishing to **npm Trusted Publishing (OIDC)** — the same mechanism [`vercel/flags`](https://github.com/vercel/flags/blob/main/.github/workflows/release.yml) — **without** adopting changesets. The workflow keeps its existing trigger (`release: [published]`) and its beta/stable split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)